### PR TITLE
Changes for 24.1 Go-Live

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This project welcomes contributions from the community. Before submitting a pull
 Please consult the [security guide](./SECURITY.md) for our responsible security vulnerability disclosure process.
 
 ## Issues
-If you encounter any issues, please consider reporting them in the [Oracle Forums](https://forums.oracle.com/ords/apexds/domain/dev-community/category/apex) to help us improve our product.
+If you encounter any issues, please consider reporting them in the [Oracle Forums](https://apex.oracle.com/forum) to help us improve our product.
 
 ## License
 Copyright (c) 2021, 2024 Oracle and/or its affiliates.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This GitHub project contains starter apps, sample apps, sample code, and plug-in
 ## Branches
 These branches contains starter apps, sample apps and so on for a specific version of Oracle APEX.
 
+- [Oracle APEX 24.1](../../tree/24.1)
 - [Oracle APEX 23.2](../../tree/23.2)
 - [Oracle APEX 23.1](../../tree/23.1)
 - [Oracle APEX 22.2](../../tree/22.2)
@@ -25,6 +26,9 @@ This project welcomes contributions from the community. Before submitting a pull
 
 ## Security
 Please consult the [security guide](./SECURITY.md) for our responsible security vulnerability disclosure process.
+
+## Issues
+If you encounter any issues, please consider reporting them in the [Oracle Forums](https://forums.oracle.com/ords/apexds/domain/dev-community/category/apex) to help us improve our product.
 
 ## License
 Copyright (c) 2021, 2023 Oracle and/or its affiliates.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Please consult the [security guide](./SECURITY.md) for our responsible security 
 If you encounter any issues, please consider reporting them in the [Oracle Forums](https://forums.oracle.com/ords/apexds/domain/dev-community/category/apex) to help us improve our product.
 
 ## License
-Copyright (c) 2021, 2023 Oracle and/or its affiliates.
+Copyright (c) 2021, 2024 Oracle and/or its affiliates.
 
 Released under the Universal Permissive License v1.0 as shown at
 <https://oss.oracle.com/licenses/upl/>.

--- a/docs/js/core.js
+++ b/docs/js/core.js
@@ -17,7 +17,7 @@
     function loadAPEXVersions() {
         const apiURL = "https://api.github.com/repos/oracle/apex/branches",
               versionURL = getURLParamValue( "version" ),
-              allowedBranches = ["21.1", "21.2", "22.1", "22.2", "23.1", "23.2"];
+              allowedBranches = ["21.1", "21.2", "22.1", "22.2", "23.1", "23.2", "24.1"];
 
         const applyVersions = function ( pData ) {
             const data = pData || [],


### PR DESCRIPTION
- Extended APEX version select list on static site to include 24.1
- Include link to 24.1 branch on main readme
- Include note about reporting issue to point to our Oracle Forums