### PR TITLE
Update GitHub Pages release selector

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
             <nav class="m-HeaderNav" id="header-nav">
               <ul class="m-HeaderNav-cta">
                 <li class="m-HeaderNav-ctaGetStarted">
-                  <a href="https://apex.oracle.com/en/learn/getting-started/">Get Started for Free</a>
+                  <a href="https://www.oracle.com/apex/getting-started/">Get Started for Free</a>
                 </li>
 
                 <li class="m-HeaderNav-ctaGitHub">
@@ -179,7 +179,7 @@
                 <h3 class="m-Notice-title">Get started with Oracle APEX today</h3>
               </div>
             </div>
-            <div class="u-Grid-col m-Notice-actions"><a href="https://apex.oracle.com/en/learn/getting-started/" class="m-Notice-cta m-Notice-cta--primary">Get Started for Free</a></div>
+            <div class="u-Grid-col m-Notice-actions"><a href="https://www.oracle.com/apex/getting-started/" class="m-Notice-cta m-Notice-cta--primary">Get Started for Free</a></div>
           </div>
         </div>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,7 @@
         <div class="m-Header-wrap u-Grid-container">
           <!-- Header Lockup -->
           <div class="m-Header-lockup">
-            <a class="m-Header-logoLink" href="https://apex.oracle.com" title="Oracle APEX">
+            <a class="m-Header-logoLink" href="https://www.oracle.com/apex/" title="Oracle APEX">
               <svg class="m-Header-logo" role="img" aria-labelledby="m-Header-logoText" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 24">
                 <title id="m-Header-logoText">Oracle</title>
                 <path d="M24.6 0C30.9 0 36 5.4 36 12s-5.1 12-11.4 12H11.4C5.1 24 0 18.6 0 12S5.1 0 11.4 0h13.2zm-.3 4H11.7c-4.1 0-7.4 3.6-7.4 8s3.3 8 7.4 8h12.6c4.1 0 7.4-3.6 7.4-8s-3.3-8-7.4-8z" fill-rule="evenodd" clip-rule="evenodd"></path>

--- a/docs/js/core.js
+++ b/docs/js/core.js
@@ -17,7 +17,7 @@
     function loadAPEXVersions() {
         const apiURL = "https://api.github.com/repos/oracle/apex/branches",
               versionURL = getURLParamValue( "version" ),
-              allowedBranches = ["21.1", "21.2", "22.1", "22.2", "23.1", "23.2", "24.1", "24.2"];
+              allowedBranches = ["21.1", "21.2", "22.1", "22.2", "23.1", "23.2", "24.1", "24.2", "26.1"];
 
         const applyVersions = function ( pData ) {
             const data = pData || [],


### PR DESCRIPTION
Add APEX 26.1 to the release selector and point Get Started links to the new Oracle APEX getting started page.